### PR TITLE
Add native support for ##XYPOINTS blocks in JCAMP reader diff

### DIFF
--- a/nmrglue/fileio/jcampdx.py
+++ b/nmrglue/fileio/jcampdx.py
@@ -523,6 +523,17 @@ def _getdataarray(dic, show_all_data=False):
         except KeyError:
             warn("PEAKTABLE not found ")
 
+    if data is None:  # XYPOINTS
+        try:
+            valuelist = dic["XYPOINTS"]
+            if len(valuelist) == 1:
+                data, datatype = _parse_data(valuelist[0])
+            else:
+                warn("Multiple XYPOINTS arrays in JCAMP-DX file, \
+                     returning first one only")
+        except KeyError:
+            warn("XYPOINTS not found ")
+
     # apply YFACTOR to data if available
     if is_ntuples:
         yfactor_r, yfactor_i = find_yfactors(dic)


### PR DESCRIPTION
## Problem
Files containing ##DATA CLASS=XYPOINTS + ##XYPOINTS=(XY..XY) aren’t parsed;
data remains None, and the subsequent data * yfactor raises a TypeError.

## Fix
Fallback to _parse_data() when a XYPOINTS section exists but no XYDATA or PEAKTABLE was found.
Logic mirrors the existing XYDATA / PEAKTABLE branches.

Tested on
[Vial 35 160 min_7213289SP.zip](https://github.com/user-attachments/files/21038364/Vial.35.160.min_7213289SP.zip)