### PR TITLE
fix: read JCAMP files with UTF‑8 to preserve unit symbols

### DIFF
--- a/nmrglue/fileio/jcampdx.py
+++ b/nmrglue/fileio/jcampdx.py
@@ -44,7 +44,7 @@ def _readrawdic(filename, read_err=None):
     '''
 
     dic = {"_comments": []}  # create empty dictionary
-    filein = open(filename, 'r', errors=read_err)
+    filein = open(filename, 'r' , encoding='utf-8', errors=read_err)
 
     currentkey = None
     currentvaluestrings = []


### PR DESCRIPTION
## Change

Open JCAMP files in UTF-8 format using jcampdx.readDrawDic.

## Why

Some JCAMP headers contain Unicode characters (e.g. ³) that were previously not displayed correctly.

For example, with this JCAMP line:

```YUNITS=cm³*K```

Chemspectra previously produced:
<img width="334" height="831" alt="Image" src="https://github.com/user-attachments/assets/37f289a3-ad03-439e-8e91-24e7512bd24b" />

After the fix:
<img width="235" height="810" alt="Image" src="https://github.com/user-attachments/assets/37b97dc7-7415-4edd-a628-953f8eaecc16" />

## Testing
- Load JCAMP files containing Unicode unit labels (XUNITS/YUNITS).
- Verify that no replacement boxes or missing characters appear.
- Confirm that all Unicode characters (e.g. ³) are displayed correctly in generated images.